### PR TITLE
Soft start on turn on (set the target position to current position) + simple grpc client listener example

### DIFF
--- a/poulpe_ethercat_controller/Cargo.toml
+++ b/poulpe_ethercat_controller/Cargo.toml
@@ -16,7 +16,7 @@ env_logger = "0.9.0"
 
 
 [features]
-default = ["verify_orbita_type", "allow_partial_network"]
+default = ["verify_orbita_type", "allow_partial_network", "safe_turn_on"]
 verify_orbita_type = [] # This feature is used to verify the type of the Orbita device connected to the EtherCAT network
                         # Verifies if the yaml file specifies the correct type of the Orbita device connected to the network (orbita2d = 2 and orbita3d = 3)
                         # If not specified this check is not performed
@@ -24,3 +24,4 @@ verify_orbita_type = [] # This feature is used to verify the type of the Orbita 
 allow_partial_network = []  # This feature enables to instantiate the ethercat master that talks to only a part of the EtherCAT slaves connected to the network 
                             # If not specified yaml file should specify all the slaves connected to the network
 
+safe_turn_on = [] # setting the current position to the target position on torque on

--- a/poulpe_ethercat_grpc/examples/client_listener.rs
+++ b/poulpe_ethercat_grpc/examples/client_listener.rs
@@ -46,9 +46,10 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 
     loop {
+        let complient = client.is_on(id).unwrap();
         let target_position = client.get_target_position(id).unwrap();
         let current_position = client.get_position_actual_value(id).unwrap();
-        log::info!("{:?}, {:?}", target_position, current_position);    
+        log::info!("{:?}, {:?}, {:?}", complient,  target_position, current_position);    
         thread::sleep(Duration::from_secs_f32(0.001));
     }
     Ok(())

--- a/target/release/server
+++ b/target/release/server
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ddfc317cd4882233b90469ba294f8f25a93afa0cd7b5e9901d5cf1e9014a9588
-size 6086296
+oid sha256:0ff8a4febf8ca299410e8b8ef3a1fde02a631aae203a91f82e52a4584efd6415
+size 6123672


### PR DESCRIPTION
Ok so this code adds a feature to the `poulpe_ethercat_controller` called `safe_turn_on` which is by default **used**. 
- When this feature is enabled, upon any turn on the target position value will be reset to the current position (and verified that it well set) before enabling the motors. 
- The feature can be disabled in the cargo.yaml of the `poulpe_ethercat_controller`.

Additionally, a new example code is added primarly for debugging purposes that is a simple listener that outputs the target position, current position of a slave with the ID provided in the argument. 