### PR TITLE
7 pass the cia402 state to the boardstate temporarily

### DIFF
--- a/poulpe_ethercat_controller/src/lib.rs
+++ b/poulpe_ethercat_controller/src/lib.rs
@@ -23,7 +23,7 @@ use ethercat_controller::{
     Config, EtherCatController,
 };
 
-mod register;
+pub mod register;
 use register::PdoRegister;
 
 #[derive(Debug)]

--- a/poulpe_ethercat_controller/src/register.rs
+++ b/poulpe_ethercat_controller/src/register.rs
@@ -1,3 +1,5 @@
+use crate::state_machine::{CiA402State, ErrorFlags, MotorErrorFlag, HomingErrorFlag };
+
 pub(crate) enum PdoRegister {
     ErrorCode,
     ActuatorType,
@@ -63,4 +65,67 @@ pub enum BoardStatus {
     Init = 20,
     HighTemperatureState = 100,
     Unknown = 255,
+}
+
+impl BoardStatus{
+    pub fn from_cia402_to_board_status(state: u32, flags: Vec<i32>) -> Result<BoardStatus, ()> {
+        let state: CiA402State = num::FromPrimitive::from_u32(state).unwrap();
+        
+        let homing_errors: Vec<HomingErrorFlag> = flags.first().map(|x| {
+            let error = u16::from_le_bytes((*x as u16).to_le_bytes());
+            let mut error_flags = Vec::new();
+            for i in 0..16 {
+                if error & (1 << i) != 0 {
+                    error_flags.push(num::FromPrimitive::from_u16(i as u16).unwrap());
+                }
+            }
+            error_flags
+        }).unwrap_or(Vec::new());
+
+        // start from the second flags element
+        let motor_errors:Vec<Vec<MotorErrorFlag>> = flags[1..].iter().map(|x| {
+            let error = u16::from_le_bytes((*x as u16).to_le_bytes());
+            let mut error_flags = Vec::new();
+            for i in 0..16 {
+                if error & (1 << i) != 0 {
+                    error_flags.push(num::FromPrimitive::from_u16(i as u16).unwrap());
+                }
+            }
+            error_flags
+        }).collect();
+
+        let flags = ErrorFlags {
+            motor_error_flags: motor_errors,
+            homing_error_flags: homing_errors
+        };
+
+        // baordstatus is much less informative than the error flags so we are obliged to make some strange decisions here
+        match state {
+            CiA402State::NotReadyToSwitchOn => Ok(BoardStatus::Init),
+            CiA402State::SwitchOnDisabled | CiA402State::ReadyToSwitchOn | CiA402State::SwitchedOn | CiA402State::OperationEnabled | CiA402State::QuickStopActive => {
+                if flags.motor_error_flags.iter().any(|x| x.contains(&MotorErrorFlag::HighTemperatureWarning)) {
+                    Ok(BoardStatus::HighTemperatureState)
+                } else {
+                    Ok(BoardStatus::Ok)
+                }
+            },
+            CiA402State::Fault | CiA402State::FaultReactionActive => {
+                if flags.motor_error_flags.iter().any(|x| x.contains(&MotorErrorFlag::OverTemperatureMotor) || x.contains(&MotorErrorFlag::OverTemperatureBoard)) {
+                    Ok(BoardStatus::OverTemperatureError)
+                } else if flags.motor_error_flags.iter().any(|x| x.contains(&MotorErrorFlag::OverCurrent)) {
+                    Ok(BoardStatus::OverCurrentError)
+                } else if flags.motor_error_flags.iter().any(|x| x.contains(&MotorErrorFlag::LowBusVoltage) || x.contains(&MotorErrorFlag::DriverFault)) {
+                    Ok(BoardStatus::BusVoltageError)
+                } else if flags.homing_error_flags.contains(&HomingErrorFlag::IndexSearchFail)  {
+                    Ok(BoardStatus::IndexError)
+                } else if flags.homing_error_flags.contains(&HomingErrorFlag::ZeroingFail) {
+                    Ok(BoardStatus::ZeroingError)
+                } else if flags.homing_error_flags.contains(&HomingErrorFlag::AxisSensorReadFail) {
+                    Ok(BoardStatus::SensorError)
+                } else {
+                    Ok(BoardStatus::InitError)
+                }
+            }
+        }
+    }
 }

--- a/poulpe_ethercat_controller/src/register.rs
+++ b/poulpe_ethercat_controller/src/register.rs
@@ -1,4 +1,4 @@
-use crate::state_machine::{CiA402State, ErrorFlags, MotorErrorFlag, HomingErrorFlag };
+use crate::state_machine::{CiA402State, ErrorFlags, HomingErrorFlag, MotorErrorFlag};
 
 pub(crate) enum PdoRegister {
     ErrorCode,
@@ -67,60 +67,93 @@ pub enum BoardStatus {
     Unknown = 255,
 }
 
-impl BoardStatus{
+impl BoardStatus {
     pub fn from_cia402_to_board_status(state: u32, flags: Vec<i32>) -> Result<BoardStatus, ()> {
         let state: CiA402State = num::FromPrimitive::from_u32(state).unwrap();
-        
-        let homing_errors: Vec<HomingErrorFlag> = flags.first().map(|x| {
-            let error = u16::from_le_bytes((*x as u16).to_le_bytes());
-            let mut error_flags = Vec::new();
-            for i in 0..16 {
-                if error & (1 << i) != 0 {
-                    error_flags.push(num::FromPrimitive::from_u16(i as u16).unwrap());
+
+        let homing_errors: Vec<HomingErrorFlag> = flags
+            .first()
+            .map(|x| {
+                let error = u16::from_le_bytes((*x as u16).to_le_bytes());
+                let mut error_flags = Vec::new();
+                for i in 0..16 {
+                    if error & (1 << i) != 0 {
+                        error_flags.push(num::FromPrimitive::from_u16(i as u16).unwrap());
+                    }
                 }
-            }
-            error_flags
-        }).unwrap_or(Vec::new());
+                error_flags
+            })
+            .unwrap_or(Vec::new());
 
         // start from the second flags element
-        let motor_errors:Vec<Vec<MotorErrorFlag>> = flags[1..].iter().map(|x| {
-            let error = u16::from_le_bytes((*x as u16).to_le_bytes());
-            let mut error_flags = Vec::new();
-            for i in 0..16 {
-                if error & (1 << i) != 0 {
-                    error_flags.push(num::FromPrimitive::from_u16(i as u16).unwrap());
+        let motor_errors: Vec<Vec<MotorErrorFlag>> = flags[1..]
+            .iter()
+            .map(|x| {
+                let error = u16::from_le_bytes((*x as u16).to_le_bytes());
+                let mut error_flags = Vec::new();
+                for i in 0..16 {
+                    if error & (1 << i) != 0 {
+                        error_flags.push(num::FromPrimitive::from_u16(i as u16).unwrap());
+                    }
                 }
-            }
-            error_flags
-        }).collect();
+                error_flags
+            })
+            .collect();
 
         let flags = ErrorFlags {
             motor_error_flags: motor_errors,
-            homing_error_flags: homing_errors
+            homing_error_flags: homing_errors,
         };
 
         // baordstatus is much less informative than the error flags so we are obliged to make some strange decisions here
         match state {
             CiA402State::NotReadyToSwitchOn => Ok(BoardStatus::Init),
-            CiA402State::SwitchOnDisabled | CiA402State::ReadyToSwitchOn | CiA402State::SwitchedOn | CiA402State::OperationEnabled | CiA402State::QuickStopActive => {
-                if flags.motor_error_flags.iter().any(|x| x.contains(&MotorErrorFlag::HighTemperatureWarning)) {
+            CiA402State::SwitchOnDisabled
+            | CiA402State::ReadyToSwitchOn
+            | CiA402State::SwitchedOn
+            | CiA402State::OperationEnabled
+            | CiA402State::QuickStopActive => {
+                if flags
+                    .motor_error_flags
+                    .iter()
+                    .any(|x| x.contains(&MotorErrorFlag::HighTemperatureWarning))
+                {
                     Ok(BoardStatus::HighTemperatureState)
                 } else {
                     Ok(BoardStatus::Ok)
                 }
-            },
+            }
             CiA402State::Fault | CiA402State::FaultReactionActive => {
-                if flags.motor_error_flags.iter().any(|x| x.contains(&MotorErrorFlag::OverTemperatureMotor) || x.contains(&MotorErrorFlag::OverTemperatureBoard)) {
+                if flags.motor_error_flags.iter().any(|x| {
+                    x.contains(&MotorErrorFlag::OverTemperatureMotor)
+                        || x.contains(&MotorErrorFlag::OverTemperatureBoard)
+                }) {
                     Ok(BoardStatus::OverTemperatureError)
-                } else if flags.motor_error_flags.iter().any(|x| x.contains(&MotorErrorFlag::OverCurrent)) {
+                } else if flags
+                    .motor_error_flags
+                    .iter()
+                    .any(|x| x.contains(&MotorErrorFlag::OverCurrent))
+                {
                     Ok(BoardStatus::OverCurrentError)
-                } else if flags.motor_error_flags.iter().any(|x| x.contains(&MotorErrorFlag::LowBusVoltage) || x.contains(&MotorErrorFlag::DriverFault)) {
+                } else if flags.motor_error_flags.iter().any(|x| {
+                    x.contains(&MotorErrorFlag::LowBusVoltage)
+                        || x.contains(&MotorErrorFlag::DriverFault)
+                }) {
                     Ok(BoardStatus::BusVoltageError)
-                } else if flags.homing_error_flags.contains(&HomingErrorFlag::IndexSearchFail)  {
+                } else if flags
+                    .homing_error_flags
+                    .contains(&HomingErrorFlag::IndexSearchFail)
+                {
                     Ok(BoardStatus::IndexError)
-                } else if flags.homing_error_flags.contains(&HomingErrorFlag::ZeroingFail) {
+                } else if flags
+                    .homing_error_flags
+                    .contains(&HomingErrorFlag::ZeroingFail)
+                {
                     Ok(BoardStatus::ZeroingError)
-                } else if flags.homing_error_flags.contains(&HomingErrorFlag::AxisSensorReadFail) {
+                } else if flags
+                    .homing_error_flags
+                    .contains(&HomingErrorFlag::AxisSensorReadFail)
+                {
                     Ok(BoardStatus::SensorError)
                 } else {
                     Ok(BoardStatus::InitError)

--- a/poulpe_ethercat_controller/src/state_machine.rs
+++ b/poulpe_ethercat_controller/src/state_machine.rs
@@ -45,7 +45,6 @@ impl ControlWord {
     }
 }
 
-
 // Error codes for the motors, we will have one error code per motor
 // - None - no error
 // - ConfigFail - error during the configuration of the motor

--- a/poulpe_ethercat_controller/src/state_machine.rs
+++ b/poulpe_ethercat_controller/src/state_machine.rs
@@ -45,6 +45,7 @@ impl ControlWord {
     }
 }
 
+
 // Error codes for the motors, we will have one error code per motor
 // - None - no error
 // - ConfigFail - error during the configuration of the motor
@@ -53,7 +54,8 @@ impl ControlWord {
 // - OverTemperature - error due to the temperature being too high
 // - OverCurrent - error due to the current being too high
 // - LowBusVoltage - error due to the bus voltage being too low
-// - CommunicationFail - error due to communication failure with the motor driver
+// - DriverFault - error due to a fault in the driver
+// - TemperatureSensorMalfunctionWarning - warning for a malfunction in the temperature sensor
 #[derive(FromPrimitive, PartialEq, Clone, Copy, Debug)]
 pub enum MotorErrorFlag {
     // None = 0,
@@ -65,13 +67,17 @@ pub enum MotorErrorFlag {
     OverCurrent = 5,
     LowBusVoltage = 6,
     DriverFault = 7,
+    TemperatureSensorMalfunctionWarning = 8,
 }
 
 // Error codes for the homing procedure
 // - None - no error
 // - AxisSensorReadFail - error during the reading of the axis sensor
+// - MotorMovementCheckFail - error during the check of the motor movement
+// - AxisSensorAlignFail - error during the alignment of the axis sensor
 // - ZeroingFail - error during the zeroing of the axis positions
 // - IndexSearchFail - error during the search of the index (only orbita3d)
+// - LowLevelCommunicaiton - error due to communication failure with the motor driver
 #[derive(FromPrimitive, PartialEq, Clone, Copy, Debug)]
 pub enum HomingErrorFlag {
     // None = 0,
@@ -80,7 +86,7 @@ pub enum HomingErrorFlag {
     AxisSensorAlignFail = 2,
     ZeroingFail = 3,
     IndexSearchFail = 4,
-    CommunicationFail = 5,
+    LowLevelCommunicaiton = 5,
 }
 
 #[derive(FromPrimitive, PartialEq, Clone, Copy, Debug)]

--- a/poulpe_ethercat_grpc/src/client.rs
+++ b/poulpe_ethercat_grpc/src/client.rs
@@ -12,6 +12,8 @@ use tokio::{
 };
 use tonic::{transport::Uri, Request};
 
+use poulpe_ethercat_controller::register::BoardStatus;
+
 #[derive(Debug)]
 enum Command {
     EmergencyStop(bool),
@@ -252,6 +254,18 @@ impl PoulpeRemoteClient {
     }
 
     pub fn get_state(&self, slave_id: u16) -> Result<u32, ()> {
+        // temporaty solution trasnforming the state to board status
+        match BoardStatus::from_cia402_to_board_status(
+            self.get_state_property(slave_id, |state| state.state, 255)?,
+            self.get_state_property(slave_id, |state| state.error_codes.clone(), vec![])?,
+        ) {
+            Ok(s) => Ok(s as u32),
+            Err(_) => Err(()),
+        }
+        // self.get_state_property(slave_id, |state| state.state, 255)
+    }
+
+    pub fn get_cia402_state(&self, slave_id: u16) -> Result<u32, ()> {
         self.get_state_property(slave_id, |state| state.state, 255)
     }
 


### PR DESCRIPTION
- client get_state returns `BoardStatus` instead of `CiA402State` - a temporary measure

- added the get_cia402_state() to the client too, getting the full state, that can be combined with the `get_error_codes` to get more info about the potential issues.