### PR TITLE
crash the server if one slave is in fault state for more than a second

### DIFF
--- a/poulpe_ethercat_controller/src/lib.rs
+++ b/poulpe_ethercat_controller/src/lib.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-mod state_machine;
+pub mod state_machine;
 use state_machine::{
     parse_homing_error_flags, parse_motor_error_flags, parse_state_from_status_bits,
     parse_status_word, CiA402State, ControlWord, ErrorFlags, StatusBit,
@@ -175,7 +175,7 @@ impl PoulpeController {
         self.set_pdo_register(slave_id, PdoRegister::ControlWord, 0, &value.to_le_bytes())
     }
 
-    fn get_error_flags(&self, slave_id: u16) -> Result<ErrorFlags, Box<dyn Error>> {
+    pub fn get_error_flags(&self, slave_id: u16) -> Result<ErrorFlags, Box<dyn Error>> {
         let error_codes = self.get_pdo_registers(slave_id, PdoRegister::ErrorCode)?;
         let homing_error_flags = parse_homing_error_flags(error_codes[0][0..2].try_into().unwrap());
         let mut motor_error_flags = vec![Vec::new(); error_codes.len() - 1];

--- a/poulpe_ethercat_grpc/Cargo.toml
+++ b/poulpe_ethercat_grpc/Cargo.toml
@@ -24,5 +24,6 @@ name = "server"
 path = "src/server.rs"
 
 [features]
-default = [] # recover_from_error]
+default = ["stop_stack_on_slave_fault"] # recover_from_error]
 recover_from_error = []
+stop_stack_on_slave_fault = []

--- a/poulpe_ethercat_grpc/examples/client_sinus.rs
+++ b/poulpe_ethercat_grpc/examples/client_sinus.rs
@@ -78,6 +78,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
         client.set_target_position(id, vec![target_position; 3]);
         thread::sleep(Duration::from_secs_f32(0.001));
+        client.turn_on(id);
     }
     Ok(())
 }

--- a/poulpe_ethercat_grpc/src/client.rs
+++ b/poulpe_ethercat_grpc/src/client.rs
@@ -12,7 +12,7 @@ use tokio::{
 };
 use tonic::{transport::Uri, Request};
 
-use poulpe_ethercat_controller::register::BoardStatus;
+use poulpe_ethercat_controller::{register::BoardStatus, state_machine::CiA402State};
 
 #[derive(Debug)]
 enum Command {


### PR DESCRIPTION
This change is behind the feature `stop_stack_on_slave_fault` in the Cargo.toml of the `poulpe_ethercat_grpc`. 

**IMPORTANT**
Enabled by default